### PR TITLE
Adding more keys for items in RecipeMaker

### DIFF
--- a/src/main/java/com/blakebr0/extendedcrafting/item/RecipeMakerItem.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/item/RecipeMakerItem.java
@@ -60,7 +60,7 @@ import net.minecraft.item.Item.Properties;
 public class RecipeMakerItem extends BaseItem implements IEnableable {
 	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 	private static final String NEW_LINE = System.lineSeparator() + "\t";
-	private static final char[] KEYS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789".toCharArray();
+	private static final char[] KEYS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789+-_*/".toCharArray();
 
 	public RecipeMakerItem(Function<Properties, Properties> properties) {
 		super(properties.compose(p -> p.stacksTo(1)));

--- a/src/main/java/com/blakebr0/extendedcrafting/item/RecipeMakerItem.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/item/RecipeMakerItem.java
@@ -60,7 +60,7 @@ import net.minecraft.item.Item.Properties;
 public class RecipeMakerItem extends BaseItem implements IEnableable {
 	private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
 	private static final String NEW_LINE = System.lineSeparator() + "\t";
-	private static final char[] KEYS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz123456789+-_*/".toCharArray();
+	private static final char[] KEYS = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+-_*/".toCharArray();
 
 	public RecipeMakerItem(Function<Properties, Properties> properties) {
 		super(properties.compose(p -> p.stacksTo(1)));


### PR DESCRIPTION
This PR adds keys to allow modpack makers to make shaped crafting recipes with 67 unique items instead of 35 (which is better for creative crafts f.i.)

**Note:** all characters in the `KEYS` field have been tested with ExtendedCrafting 3.1.11 (and Forge 36.2.26)