### PR TITLE
Allow Quantum Compressor to hold multiple variants of an item

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -90,7 +90,7 @@ dependencies {
 
     implementation findProject(':Cucumber') ?: fg.deobf("com.blakebr0.cucumber:Cucumber:${cucumber_version}")
     implementation fg.deobf("curse.maven:jade-324717:${jade_version}")
-    compileOnly fg.deobf("com.blamejared.crafttweaker:CraftTweaker-forge-${crafttweaker_version}") // TODO: implementation
+    implementation fg.deobf("com.blamejared.crafttweaker:CraftTweaker-forge-${crafttweaker_version}")
 
     runtimeOnly fg.deobf("vazkii.patchouli:Patchouli:${patchouli_version}")
     runtimeOnly fg.deobf("mezz.jei:jei-${mc_version}-forge:${jei_version}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,7 +3,7 @@
 org.gradle.jvmargs=-Xmx3G
 org.gradle.daemon=false
 
-forge_version=1.19.2-43.0.0
+forge_version=1.19.2-43.1.1
 mc_version=1.19.1
 cucumber_version=1.19.2-6.0.2
 jei_version=11.2.0.241

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,4 +9,4 @@ cucumber_version=1.19.2-6.0.2
 jei_version=11.2.0.241
 jade_version=3903693
 patchouli_version=1.19-75
-crafttweaker_version=1.18.2:9.1.116
+crafttweaker_version=1.19.2:10.0.7

--- a/src/main/java/com/blakebr0/extendedcrafting/client/screen/CompressorScreen.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/client/screen/CompressorScreen.java
@@ -57,13 +57,21 @@ public class CompressorScreen extends BaseContainerScreen<CompressorContainer> {
 			if (this.getMaterialCount() < 1) {
 				tooltip.add(ModTooltips.EMPTY.color(ChatFormatting.WHITE).build());
 			} else {
-				if (this.hasMaterialStack()) {
-					tooltip.add(this.getMaterialStackDisplayName());
-				}
-
 				var text = Component.literal(number(this.getMaterialCount()) + " / " + number(this.getMaterialsRequired()));
 
 				tooltip.add(text);
+
+				if (this.hasMaterialStack()) {
+					var inputs = this.tile.getInputs();
+					var size = inputs.size();
+					for (int i = 0; i < size && i < 5; i++) {
+						tooltip.add(inputs.get(i).getDisplayName());
+					}
+
+					if (size > 5) {
+						tooltip.add(ModTooltips.AND_X_MORE.args(size - 5).build());
+					}
+				}
 			}
 
 			this.renderComponentTooltip(matrix, tooltip, mouseX, mouseY);
@@ -116,23 +124,6 @@ public class CompressorScreen extends BaseContainerScreen<CompressorContainer> {
 		if (this.isLimitingInput()) {
 			this.blit(stack, x + 90, y + 74, 203, 56, 9, 10);
 		}
-	}
-
-	private Component getMaterialStackDisplayName() {
-		var level = this.getMinecraft().level;
-
-		if (level != null) {
-			var container = this.getMenu();
-			var tile = level.getBlockEntity(container.getPos());
-
-			if (tile instanceof CompressorTileEntity compressor) {
-				var materialStack = compressor.getMaterialStack();
-
-				return materialStack.getHoverName();
-			}
-		}
-
-		return Component.literal("");
 	}
 
 	private CompressorTileEntity getTileEntity() {

--- a/src/main/java/com/blakebr0/extendedcrafting/compat/crafttweaker/CraftTweakerUtils.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/compat/crafttweaker/CraftTweakerUtils.java
@@ -1,7 +1,7 @@
 package com.blakebr0.extendedcrafting.compat.crafttweaker;
 
 import com.blamejared.crafttweaker.api.data.MapData;
-import com.blamejared.crafttweaker.api.data.base.visitor.DataToTextComponentVisitor;
+import com.blamejared.crafttweaker.api.data.visitor.DataToTextComponentVisitor;
 import net.minecraft.nbt.CompoundTag;
 
 public final class CraftTweakerUtils {

--- a/src/main/java/com/blakebr0/extendedcrafting/lib/ModTooltips.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/lib/ModTooltips.java
@@ -17,6 +17,7 @@ public final class ModTooltips {
     public static final Tooltip TYPE = new Tooltip("tooltip.extendedcrafting.type");
     public static final Tooltip MODE = new Tooltip("tooltip.extendedcrafting.mode");
     public static final Tooltip NUM_ITEMS = new Tooltip("tooltip.extendedcrafting.num_items");
+    public static final Tooltip AND_X_MORE = new Tooltip("tooltip.extendedcrafting.and_x_more");
     public static final Tooltip TICKS = new Tooltip("tooltip.extendedcrafting.ticks");
     public static final Tooltip SECONDS = new Tooltip("tooltip.extendedcrafting.seconds");
     public static final Tooltip REQUIRES_TABLE = new Tooltip("tooltip.extendedcrafting.requires_table");

--- a/src/main/resources/assets/extendedcrafting/lang/en_us.json
+++ b/src/main/resources/assets/extendedcrafting/lang/en_us.json
@@ -93,6 +93,7 @@
   "tooltip.extendedcrafting.mode": "Mode: %s",
   "tooltip.extendedcrafting.type": "Type: %s",
   "tooltip.extendedcrafting.num_items": "%s Items",
+  "tooltip.extendedcrafting.and_x_more": "And %s more...",
   "tooltip.extendedcrafting.ticks": "%s Ticks",
   "tooltip.extendedcrafting.seconds": "%s Seconds",
   "tooltip.extendedcrafting.requires_table": "Requires Tier %s Crafting Table",


### PR DESCRIPTION
This would allow for items with slightly varied NBT to be used in the same recipe. This would also allow recipes to accept multiple different items (ex. tags, multi-item ingredients) for a single output.

- [x] Allow input of up to 100 different item variants
- [x] Works with tags and multi-item ingredients
- [x] Accounts for NBT tag fuzzy matching (ex. no nbt in recipe means anything goes, nbt in recipe is fuzzy(?))
- [x] Input bar tooltip shows first 5 or 10 items, total/required, combined extras stats

closes #145