### PR TITLE
Fix elite table gui not opening

### DIFF
--- a/src/main/java/com/blakebr0/extendedcrafting/block/EliteTableBlock.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/block/EliteTableBlock.java
@@ -6,6 +6,7 @@ import com.blakebr0.extendedcrafting.lib.ModTooltips;
 import com.blakebr0.extendedcrafting.tileentity.EliteTableTileEntity;
 import net.minecraft.core.BlockPos;
 import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.Containers;
 import net.minecraft.world.InteractionHand;
 import net.minecraft.world.InteractionResult;
@@ -50,7 +51,7 @@ public class EliteTableBlock extends BaseTileEntityBlock {
 			var tile = level.getBlockEntity(pos);
 
 			if (tile instanceof EliteTableTileEntity table) {
-				player.openMenu(table);
+				NetworkHooks.openScreen((ServerPlayer) player, table, pos);
 			}
 		}
 


### PR DESCRIPTION
fix an error where the elite table container could not read block pos because buffer was null