### PR TITLE
Only look for recipes server side to avoid lag.

### DIFF
--- a/src/main/java/com/blakebr0/extendedcrafting/container/AdvancedAutoTableContainer.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/container/AdvancedAutoTableContainer.java
@@ -60,6 +60,9 @@ public class AdvancedAutoTableContainer extends BaseContainerMenu {
 
 	@Override
 	public void slotsChanged(Container matrix) {
+		if (this.level.isClientSide) {
+			return;
+		}
 		var recipe = this.level.getRecipeManager().getRecipeFor(ModRecipeTypes.TABLE.get(), matrix, this.level);
 
 		if (recipe.isPresent()) {

--- a/src/main/java/com/blakebr0/extendedcrafting/container/AdvancedTableContainer.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/container/AdvancedTableContainer.java
@@ -57,6 +57,9 @@ public class AdvancedTableContainer extends BaseContainerMenu {
 
 	@Override
 	public void slotsChanged(Container matrix) {
+		if (this.level.isClientSide) {
+			return;
+		}
 		var recipe = this.level.getRecipeManager().getRecipeFor(ModRecipeTypes.TABLE.get(), matrix, this.level);
 
 		if (recipe.isPresent()) {

--- a/src/main/java/com/blakebr0/extendedcrafting/container/BasicAutoTableContainer.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/container/BasicAutoTableContainer.java
@@ -64,6 +64,9 @@ public class BasicAutoTableContainer extends BaseContainerMenu {
 
 	@Override
 	public void slotsChanged(Container matrix) {
+		if (this.level.isClientSide) {
+			return;
+		}
 		var recipe = this.level.getRecipeManager().getRecipeFor(ModRecipeTypes.TABLE.get(), matrix, this.level);
 
 		this.isVanillaRecipe = false;

--- a/src/main/java/com/blakebr0/extendedcrafting/container/BasicTableContainer.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/container/BasicTableContainer.java
@@ -61,6 +61,9 @@ public class BasicTableContainer extends BaseContainerMenu {
 
 	@Override
 	public void slotsChanged(Container matrix) {
+		if (this.level.isClientSide) {
+			return;
+		}
 		var recipe = this.level.getRecipeManager().getRecipeFor(ModRecipeTypes.TABLE.get(), matrix, this.level);
 
 		this.isVanillaRecipe = false;

--- a/src/main/java/com/blakebr0/extendedcrafting/container/EliteAutoTableContainer.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/container/EliteAutoTableContainer.java
@@ -60,6 +60,9 @@ public class EliteAutoTableContainer extends BaseContainerMenu {
 
 	@Override
 	public void slotsChanged(Container matrix) {
+		if (this.level.isClientSide) {
+			return;
+		}
 		var recipe = this.level.getRecipeManager().getRecipeFor(ModRecipeTypes.TABLE.get(), matrix, this.level);
 
 		if (recipe.isPresent()) {

--- a/src/main/java/com/blakebr0/extendedcrafting/container/EliteTableContainer.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/container/EliteTableContainer.java
@@ -57,6 +57,9 @@ public class EliteTableContainer extends BaseContainerMenu {
 
 	@Override
 	public void slotsChanged(Container matrix) {
+		if (this.level.isClientSide) {
+			return;
+		}
 		var recipe = this.level.getRecipeManager().getRecipeFor(ModRecipeTypes.TABLE.get(), matrix, this.level);
 
 		if (recipe.isPresent()) {

--- a/src/main/java/com/blakebr0/extendedcrafting/container/UltimateAutoTableContainer.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/container/UltimateAutoTableContainer.java
@@ -60,6 +60,9 @@ public class UltimateAutoTableContainer extends BaseContainerMenu {
 
 	@Override
 	public void slotsChanged(Container matrix) {
+		if (this.level.isClientSide) {
+			return;
+		}
 		var recipe = this.level.getRecipeManager().getRecipeFor(ModRecipeTypes.TABLE.get(), matrix, this.level);
 
 		if (recipe.isPresent()) {

--- a/src/main/java/com/blakebr0/extendedcrafting/container/UltimateTableContainer.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/container/UltimateTableContainer.java
@@ -57,6 +57,9 @@ public class UltimateTableContainer extends BaseContainerMenu {
 
 	@Override
 	public void slotsChanged(Container matrix) {
+		if (this.level.isClientSide) {
+			return;
+		}
 		var recipe = this.level.getRecipeManager().getRecipeFor(ModRecipeTypes.TABLE.get(), matrix, this.level);
 
 		if (recipe.isPresent()) {


### PR DESCRIPTION
The rationale behind this change is that slotsChanged() gets called for each slot of the containers when they are opened on the client side, so it is very wasteful to look for recipes each time. As far as I can tell the server syncs recipe result updates anyway, so this should be fine. 

I couldn't find any reason why the client would need to look for recipes, please let me know if there is one. 