### PR TITLE
Refactor recipe category implementations to use RecipeHolder

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ parchment_minecraft_version=1.21
 parchment_mappings_version=2024.07.28
 
 cucumber_version=1.21.1-8.0.13
-jei_version=19.16.1.156
+jei_version=19.16.5.185
 jei_mc_version=1.21.1
 jade_version=5591256
 patchouli_version=1.21-87-NEOFORGE

--- a/src/main/java/com/blakebr0/extendedcrafting/compat/jei/JeiCompat.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/compat/jei/JeiCompat.java
@@ -109,15 +109,14 @@ public final class JeiCompat implements IModPlugin {
             var manager = level.getRecipeManager();
 
             if (ModConfigs.ENABLE_CRAFTING_CORE.get()) {
-                registration.addRecipes(CombinationCraftingCategory.RECIPE_TYPE, RecipeHelper.byTypeValues(manager, ModRecipeTypes.COMBINATION.get()));
+                registration.addRecipes(CombinationCraftingCategory.RECIPE_TYPE, RecipeHelper.byType(manager, ModRecipeTypes.COMBINATION.get()).stream().toList());
             }
 
             if (ModConfigs.ENABLE_TABLES.get()) {
                 var recipes = Stream.of(1, 2, 3, 4).collect(Collectors.toMap(tier -> tier, tier ->
                         RecipeHelper.byType(manager, ModRecipeTypes.TABLE.get())
                                 .stream()
-                                .map(RecipeHolder::value)
-                                .filter(recipe -> recipe.hasRequiredTier() ? tier == recipe.getTier() : tier >= recipe.getTier())
+                                .filter(recipe -> recipe.value().hasRequiredTier() ? tier == recipe.value().getTier() : tier >= recipe.value().getTier())
                                 .toList()
                 ));
 
@@ -128,15 +127,15 @@ public final class JeiCompat implements IModPlugin {
             }
 
             if (ModConfigs.ENABLE_COMPRESSOR.get()) {
-                registration.addRecipes(CompressorCraftingCategory.RECIPE_TYPE, RecipeHelper.byTypeValues(manager, ModRecipeTypes.COMPRESSOR.get()));
+                registration.addRecipes(CompressorCraftingCategory.RECIPE_TYPE, RecipeHelper.byType(manager, ModRecipeTypes.COMPRESSOR.get()).stream().toList());
             }
 
             if (ModConfigs.ENABLE_ENDER_CRAFTER.get()) {
-                registration.addRecipes(EnderCrafterCategory.RECIPE_TYPE, RecipeHelper.byTypeValues(manager, ModRecipeTypes.ENDER_CRAFTER.get()));
+                registration.addRecipes(EnderCrafterCategory.RECIPE_TYPE, RecipeHelper.byType(manager, ModRecipeTypes.ENDER_CRAFTER.get()).stream().toList());
             }
 
             if (ModConfigs.ENABLE_FLUX_CRAFTER.get()) {
-                registration.addRecipes(FluxCraftingCategory.RECIPE_TYPE, RecipeHelper.byTypeValues(manager, ModRecipeTypes.FLUX_CRAFTER.get()));
+                registration.addRecipes(FluxCraftingCategory.RECIPE_TYPE, RecipeHelper.byType(manager, ModRecipeTypes.FLUX_CRAFTER.get()).stream().toList());
             }
         }
     }

--- a/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/CombinationCraftingCategory.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/CombinationCraftingCategory.java
@@ -19,12 +19,13 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
 import java.awt.*;
 
-public class CombinationCraftingCategory implements IRecipeCategory<ICombinationRecipe> {
+public class CombinationCraftingCategory implements IRecipeCategory<RecipeHolder<ICombinationRecipe>> {
 	private static final ResourceLocation TEXTURE = ExtendedCrafting.resource("textures/jei/combination_crafting.png");
-	public static final RecipeType<ICombinationRecipe> RECIPE_TYPE = RecipeType.create(ExtendedCrafting.MOD_ID, "combination", ICombinationRecipe.class);
+	public static final RecipeType<RecipeHolder<ICombinationRecipe>> RECIPE_TYPE = RecipeType.createRecipeHolderType(ExtendedCrafting.resource("combination"));
 
 	private final IDrawable background;
 	private final IDrawable icon;
@@ -34,12 +35,12 @@ public class CombinationCraftingCategory implements IRecipeCategory<ICombination
 		this.icon = helper.createDrawableIngredient(VanillaTypes.ITEM_STACK, new ItemStack(ModBlocks.CRAFTING_CORE.get()));
 	}
 
-	@Override
-	public RecipeType<ICombinationRecipe> getRecipeType() {
-		return RECIPE_TYPE;
-	}
+    @Override
+    public RecipeType<RecipeHolder<ICombinationRecipe>> getRecipeType() {
+        return RECIPE_TYPE;
+    }
 
-	@Override
+    @Override
 	public Component getTitle() {
 		return Localizable.of("jei.category.extendedcrafting.combination").build();
 	}
@@ -54,8 +55,10 @@ public class CombinationCraftingCategory implements IRecipeCategory<ICombination
 		return this.icon;
 	}
 
-	@Override
-	public void getTooltip(ITooltipBuilder tooltip, ICombinationRecipe recipe, IRecipeSlotsView slots, double mouseX, double mouseY) {
+    @Override
+	public void getTooltip(ITooltipBuilder tooltip, RecipeHolder<ICombinationRecipe> recipeHolder, IRecipeSlotsView slots, double mouseX, double mouseY) {
+        var recipe = recipeHolder.value();
+
 		if (mouseX > 1 && mouseX < 14 && mouseY > 9 && mouseY < 86) {
 			tooltip.add(Formatting.energy(recipe.getPowerCost()));
 			tooltip.add(Formatting.energyPerTick(recipe.getPowerRate()));
@@ -67,7 +70,8 @@ public class CombinationCraftingCategory implements IRecipeCategory<ICombination
 	}
 
 	@Override
-	public void setRecipe(IRecipeLayoutBuilder builder, ICombinationRecipe recipe, IFocusGroup focuses) {
+	public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<ICombinationRecipe> recipeHolder, IFocusGroup focuses) {
+        var recipe = recipeHolder.value();
 		var level = Minecraft.getInstance().level;
 
 		assert level != null;

--- a/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/CompressorCraftingCategory.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/CompressorCraftingCategory.java
@@ -21,10 +21,11 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
-public class CompressorCraftingCategory implements IRecipeCategory<ICompressorRecipe> {
+public class CompressorCraftingCategory implements IRecipeCategory<RecipeHolder<ICompressorRecipe>> {
 	private static final ResourceLocation TEXTURE = ExtendedCrafting.resource("textures/jei/compressor.png");
-	public static final RecipeType<ICompressorRecipe> RECIPE_TYPE = RecipeType.create(ExtendedCrafting.MOD_ID, "compressor", ICompressorRecipe.class);
+	public static final RecipeType<RecipeHolder<ICompressorRecipe>> RECIPE_TYPE = RecipeType.createRecipeHolderType(ExtendedCrafting.resource("compressor"));
 
 	private final IDrawable background;
 	private final IDrawable icon;
@@ -35,7 +36,7 @@ public class CompressorCraftingCategory implements IRecipeCategory<ICompressorRe
 	}
 
 	@Override
-	public RecipeType<ICompressorRecipe> getRecipeType() {
+	public RecipeType<RecipeHolder<ICompressorRecipe>> getRecipeType() {
 		return RECIPE_TYPE;
 	}
 
@@ -55,7 +56,9 @@ public class CompressorCraftingCategory implements IRecipeCategory<ICompressorRe
 	}
 
 	@Override
-	public void getTooltip(ITooltipBuilder tooltip, ICompressorRecipe recipe, IRecipeSlotsView slots, double mouseX, double mouseY) {
+	public void getTooltip(ITooltipBuilder tooltip, RecipeHolder<ICompressorRecipe> recipeHolder, IRecipeSlotsView slots, double mouseX, double mouseY) {
+        var recipe = recipeHolder.value();
+
 		if (mouseX > 1 && mouseX < 14 && mouseY > 1 && mouseY < 78) {
 			tooltip.add(Formatting.energy(recipe.getPowerCost()));
 			tooltip.add(Formatting.energyPerTick(recipe.getPowerRate()));
@@ -67,7 +70,8 @@ public class CompressorCraftingCategory implements IRecipeCategory<ICompressorRe
 	}
 
 	@Override
-	public void setRecipe(IRecipeLayoutBuilder builder, ICompressorRecipe recipe, IFocusGroup focuses) {
+	public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<ICompressorRecipe> recipeHolder, IFocusGroup focuses) {
+        var recipe = recipeHolder.value();
 		var level = Minecraft.getInstance().level;
 
 		assert level != null;

--- a/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/EnderCrafterCategory.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/EnderCrafterCategory.java
@@ -24,10 +24,11 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
-public class EnderCrafterCategory implements IRecipeCategory<IEnderCrafterRecipe> {
+public class EnderCrafterCategory implements IRecipeCategory<RecipeHolder<IEnderCrafterRecipe>> {
 	private static final ResourceLocation TEXTURE = ExtendedCrafting.resource("textures/jei/ender_crafting.png");
-	public static final RecipeType<IEnderCrafterRecipe> RECIPE_TYPE = RecipeType.create(ExtendedCrafting.MOD_ID, "ender_crafting", IEnderCrafterRecipe.class);
+	public static final RecipeType<RecipeHolder<IEnderCrafterRecipe>> RECIPE_TYPE = RecipeType.createRecipeHolderType(ExtendedCrafting.resource("ender_crafting"));
 
 	private final IDrawable background;
 	private final IDrawableAnimated arrow;
@@ -43,7 +44,7 @@ public class EnderCrafterCategory implements IRecipeCategory<IEnderCrafterRecipe
 	}
 
 	@Override
-	public RecipeType<IEnderCrafterRecipe> getRecipeType() {
+	public RecipeType<RecipeHolder<IEnderCrafterRecipe>> getRecipeType() {
 		return RECIPE_TYPE;
 	}
 
@@ -63,19 +64,22 @@ public class EnderCrafterCategory implements IRecipeCategory<IEnderCrafterRecipe
 	}
 
 	@Override
-	public void draw(IEnderCrafterRecipe recipe, IRecipeSlotsView slots, GuiGraphics gfx, double mouseX, double mouseY) {
+	public void draw(RecipeHolder<IEnderCrafterRecipe> recipe, IRecipeSlotsView slots, GuiGraphics gfx, double mouseX, double mouseY) {
 		this.arrow.draw(gfx, 61, 19);
 	}
 
 	@Override
-	public void getTooltip(ITooltipBuilder tooltip, IEnderCrafterRecipe recipe, IRecipeSlotsView slots, double mouseX, double mouseY) {
+	public void getTooltip(ITooltipBuilder tooltip, RecipeHolder<IEnderCrafterRecipe> recipeHolder, IRecipeSlotsView slots, double mouseX, double mouseY) {
+        var recipe = recipeHolder.value();
+
 		if (mouseX > 60 && mouseX < 83 && mouseY > 19 && mouseY < 34) {
 			tooltip.add(ModTooltips.SECONDS.args(recipe.getCraftingTime()).color(ChatFormatting.WHITE).build());
 		}
 	}
 
 	@Override
-	public void setRecipe(IRecipeLayoutBuilder builder, IEnderCrafterRecipe recipe, IFocusGroup focuses) {
+	public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<IEnderCrafterRecipe> recipeHolder, IFocusGroup focuses) {
+        var recipe = recipeHolder.value();
 		var level = Minecraft.getInstance().level;
 
 		assert level != null;

--- a/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/FluxCraftingCategory.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/FluxCraftingCategory.java
@@ -23,10 +23,11 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
-public class FluxCraftingCategory implements IRecipeCategory<IFluxCrafterRecipe> {
+public class FluxCraftingCategory implements IRecipeCategory<RecipeHolder<IFluxCrafterRecipe>> {
 	private static final ResourceLocation TEXTURE = ExtendedCrafting.resource("textures/jei/flux_crafting.png");
-	public static final RecipeType<IFluxCrafterRecipe> RECIPE_TYPE = RecipeType.create(ExtendedCrafting.MOD_ID, "flux_crafting", IFluxCrafterRecipe.class);
+	public static final RecipeType<RecipeHolder<IFluxCrafterRecipe>> RECIPE_TYPE = RecipeType.createRecipeHolderType(ExtendedCrafting.resource("flux_crafting"));
 
 	private final IDrawable background;
 	private final IDrawable icon;
@@ -37,7 +38,7 @@ public class FluxCraftingCategory implements IRecipeCategory<IFluxCrafterRecipe>
 	}
 
 	@Override
-	public RecipeType<IFluxCrafterRecipe> getRecipeType() {
+	public RecipeType<RecipeHolder<IFluxCrafterRecipe>> getRecipeType() {
 		return RECIPE_TYPE;
 	}
 
@@ -57,7 +58,9 @@ public class FluxCraftingCategory implements IRecipeCategory<IFluxCrafterRecipe>
 	}
 
 	@Override
-	public void getTooltip(ITooltipBuilder tooltip, IFluxCrafterRecipe recipe, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
+	public void getTooltip(ITooltipBuilder tooltip, RecipeHolder<IFluxCrafterRecipe> recipeHolder, IRecipeSlotsView recipeSlotsView, double mouseX, double mouseY) {
+        var recipe = recipeHolder.value();
+        
 		if (mouseX > 1 && mouseX < 14 && mouseY > 1 && mouseY < 78) {
 			tooltip.add(Formatting.energy(recipe.getPowerRequired()));
 			tooltip.add(ModTooltips.PER_ALTERNATOR.args(Formatting.energyPerTick(recipe.getPowerRate())).color(ChatFormatting.WHITE).build());
@@ -65,7 +68,8 @@ public class FluxCraftingCategory implements IRecipeCategory<IFluxCrafterRecipe>
 	}
 
 	@Override
-	public void setRecipe(IRecipeLayoutBuilder builder, IFluxCrafterRecipe recipe, IFocusGroup focuses) {
+	public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<IFluxCrafterRecipe> recipeHolder, IFocusGroup focuses) {
+        var recipe = recipeHolder.value();
 		var level = Minecraft.getInstance().level;
 
 		assert level != null;

--- a/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/table/AdvancedTableCategory.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/table/AdvancedTableCategory.java
@@ -24,10 +24,11 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
-public class AdvancedTableCategory implements IRecipeCategory<ITableRecipe> {
+public class AdvancedTableCategory implements IRecipeCategory<RecipeHolder<ITableRecipe>> {
 	private static final ResourceLocation TEXTURE = ExtendedCrafting.resource("textures/jei/advanced_crafting.png");
-	public static final RecipeType<ITableRecipe> RECIPE_TYPE = RecipeType.create(ExtendedCrafting.MOD_ID, "advanced_crafting", ITableRecipe.class);
+	public static final RecipeType<RecipeHolder<ITableRecipe>> RECIPE_TYPE = RecipeType.createRecipeHolderType(ExtendedCrafting.resource("advanced_crafting"));
 
 	private final IDrawable background;
 	private final IDrawable icon;
@@ -40,7 +41,7 @@ public class AdvancedTableCategory implements IRecipeCategory<ITableRecipe> {
 	}
 
 	@Override
-	public RecipeType<ITableRecipe> getRecipeType() {
+	public RecipeType<RecipeHolder<ITableRecipe>> getRecipeType() {
 		return RECIPE_TYPE;
 	}
 
@@ -60,7 +61,8 @@ public class AdvancedTableCategory implements IRecipeCategory<ITableRecipe> {
 	}
 
 	@Override
-	public void draw(ITableRecipe recipe, IRecipeSlotsView slots, GuiGraphics gfx, double mouseX, double mouseY) {
+	public void draw(RecipeHolder<ITableRecipe> recipeHolder, IRecipeSlotsView slots, GuiGraphics gfx, double mouseX, double mouseY) {
+        var recipe = recipeHolder.value();
 		var matrix = gfx.pose();
 
 		matrix.pushPose();
@@ -75,7 +77,8 @@ public class AdvancedTableCategory implements IRecipeCategory<ITableRecipe> {
 	}
 
 	@Override
-	public void getTooltip(ITooltipBuilder tooltip, ITableRecipe recipe, IRecipeSlotsView slots, double mouseX, double mouseY) {
+	public void getTooltip(ITooltipBuilder tooltip, RecipeHolder<ITableRecipe> recipeHolder, IRecipeSlotsView slots, double mouseX, double mouseY) {
+        var recipe = recipeHolder.value();
 		var shapeless = recipe instanceof ShapelessTableRecipe;
 		int sX = (shapeless ? 265 : 285) / 2, sY = 0;
 
@@ -85,7 +88,8 @@ public class AdvancedTableCategory implements IRecipeCategory<ITableRecipe> {
 	}
 
 	@Override
-	public void setRecipe(IRecipeLayoutBuilder builder, ITableRecipe recipe, IFocusGroup focuses) {
+	public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<ITableRecipe> recipeHolder, IFocusGroup focuses) {
+        var recipe = recipeHolder.value();
 		var level = Minecraft.getInstance().level;
 
 		assert level != null;

--- a/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/table/BasicTableCategory.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/table/BasicTableCategory.java
@@ -24,10 +24,11 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
-public class BasicTableCategory implements IRecipeCategory<ITableRecipe> {
+public class BasicTableCategory implements IRecipeCategory<RecipeHolder<ITableRecipe>> {
 	private static final ResourceLocation TEXTURE = ExtendedCrafting.resource("textures/jei/basic_crafting.png");
-	public static final RecipeType<ITableRecipe> RECIPE_TYPE = RecipeType.create(ExtendedCrafting.MOD_ID, "basic_crafting", ITableRecipe.class);
+	public static final RecipeType<RecipeHolder<ITableRecipe>> RECIPE_TYPE = RecipeType.createRecipeHolderType(ExtendedCrafting.resource("basic_crafting"));
 
 	private final IDrawable background;
 	private final IDrawable icon;
@@ -40,7 +41,7 @@ public class BasicTableCategory implements IRecipeCategory<ITableRecipe> {
 	}
 
 	@Override
-	public RecipeType<ITableRecipe> getRecipeType() {
+	public RecipeType<RecipeHolder<ITableRecipe>> getRecipeType() {
 		return RECIPE_TYPE;
 	}
 
@@ -60,7 +61,8 @@ public class BasicTableCategory implements IRecipeCategory<ITableRecipe> {
 	}
 
 	@Override
-	public void draw(ITableRecipe recipe, IRecipeSlotsView slots, GuiGraphics gfx, double mouseX, double mouseY) {
+	public void draw(RecipeHolder<ITableRecipe> recipeHolder, IRecipeSlotsView slots, GuiGraphics gfx, double mouseX, double mouseY) {
+        var recipe = recipeHolder.value();
 		var matrix = gfx.pose();
 
 		matrix.pushPose();
@@ -75,7 +77,8 @@ public class BasicTableCategory implements IRecipeCategory<ITableRecipe> {
 	}
 
 	@Override
-	public void getTooltip(ITooltipBuilder tooltip, ITableRecipe recipe, IRecipeSlotsView slots, double mouseX, double mouseY) {
+	public void getTooltip(ITooltipBuilder tooltip, RecipeHolder<ITableRecipe> recipeHolder, IRecipeSlotsView slots, double mouseX, double mouseY) {
+        var recipe = recipeHolder.value();
 		var shapeless = recipe instanceof ShapelessTableRecipe;
 		int sX = (shapeless ? 197 : 217) / 2, sY = 0;
 
@@ -85,7 +88,8 @@ public class BasicTableCategory implements IRecipeCategory<ITableRecipe> {
 	}
 
 	@Override
-	public void setRecipe(IRecipeLayoutBuilder builder, ITableRecipe recipe, IFocusGroup focuses) {
+	public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<ITableRecipe> recipeHolder, IFocusGroup focuses) {
+        var recipe = recipeHolder.value();
 		var level = Minecraft.getInstance().level;
 
 		assert level != null;

--- a/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/table/EliteTableCategory.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/table/EliteTableCategory.java
@@ -24,10 +24,11 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
-public class EliteTableCategory implements IRecipeCategory<ITableRecipe> {
+public class EliteTableCategory implements IRecipeCategory<RecipeHolder<ITableRecipe>> {
 	private static final ResourceLocation TEXTURE = ExtendedCrafting.resource("textures/jei/elite_crafting.png");
-	public static final RecipeType<ITableRecipe> RECIPE_TYPE = RecipeType.create(ExtendedCrafting.MOD_ID, "elite_crafting", ITableRecipe.class);
+	public static final RecipeType<RecipeHolder<ITableRecipe>> RECIPE_TYPE = RecipeType.createRecipeHolderType(ExtendedCrafting.resource("elite_crafting"));
 
 	private final IDrawable background;
 	private final IDrawable icon;
@@ -40,7 +41,7 @@ public class EliteTableCategory implements IRecipeCategory<ITableRecipe> {
 	}
 
 	@Override
-	public RecipeType<ITableRecipe> getRecipeType() {
+	public RecipeType<RecipeHolder<ITableRecipe>> getRecipeType() {
 		return RECIPE_TYPE;
 	}
 
@@ -60,7 +61,8 @@ public class EliteTableCategory implements IRecipeCategory<ITableRecipe> {
 	}
 
 	@Override
-	public void draw(ITableRecipe recipe, IRecipeSlotsView slots, GuiGraphics gfx, double mouseX, double mouseY) {
+	public void draw(RecipeHolder<ITableRecipe> recipeHolder, IRecipeSlotsView slots, GuiGraphics gfx, double mouseX, double mouseY) {
+        var recipe = recipeHolder.value();
 		var matrix = gfx.pose();
 
 		matrix.pushPose();
@@ -75,7 +77,8 @@ public class EliteTableCategory implements IRecipeCategory<ITableRecipe> {
 	}
 
 	@Override
-	public void getTooltip(ITooltipBuilder tooltip, ITableRecipe recipe, IRecipeSlotsView slots, double mouseX, double mouseY) {
+	public void getTooltip(ITooltipBuilder tooltip, RecipeHolder<ITableRecipe> recipeHolder, IRecipeSlotsView slots, double mouseX, double mouseY) {
+        var recipe = recipeHolder.value();
 		var shapeless = recipe instanceof ShapelessTableRecipe;
 		int sX = (shapeless ? 217 : 237) / 2, sY = 257 / 2;
 
@@ -85,7 +88,8 @@ public class EliteTableCategory implements IRecipeCategory<ITableRecipe> {
 	}
 
 	@Override
-	public void setRecipe(IRecipeLayoutBuilder builder, ITableRecipe recipe, IFocusGroup focuses) {
+	public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<ITableRecipe> recipeHolder, IFocusGroup focuses) {
+        var recipe = recipeHolder.value();
 		var level = Minecraft.getInstance().level;
 
 		assert level != null;

--- a/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/table/UltimateTableCategory.java
+++ b/src/main/java/com/blakebr0/extendedcrafting/compat/jei/category/table/UltimateTableCategory.java
@@ -24,10 +24,11 @@ import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.RecipeHolder;
 
-public class UltimateTableCategory implements IRecipeCategory<ITableRecipe> {
+public class UltimateTableCategory implements IRecipeCategory<RecipeHolder<ITableRecipe>> {
 	private static final ResourceLocation TEXTURE = ExtendedCrafting.resource("textures/jei/ultimate_crafting.png");
-	public static final RecipeType<ITableRecipe> RECIPE_TYPE = RecipeType.create(ExtendedCrafting.MOD_ID, "ultimate_crafting", ITableRecipe.class);
+	public static final RecipeType<RecipeHolder<ITableRecipe>> RECIPE_TYPE = RecipeType.createRecipeHolderType(ExtendedCrafting.resource("ultimate_crafting"));
 
     private final IDrawable background;
     private final IDrawable icon;
@@ -40,7 +41,7 @@ public class UltimateTableCategory implements IRecipeCategory<ITableRecipe> {
     }
 
 	@Override
-	public RecipeType<ITableRecipe> getRecipeType() {
+	public RecipeType<RecipeHolder<ITableRecipe>> getRecipeType() {
 		return RECIPE_TYPE;
 	}
 
@@ -60,7 +61,8 @@ public class UltimateTableCategory implements IRecipeCategory<ITableRecipe> {
 	}
 
 	@Override
-	public void draw(ITableRecipe recipe, IRecipeSlotsView slots, GuiGraphics gfx, double mouseX, double mouseY) {
+	public void draw(RecipeHolder<ITableRecipe> recipeHolder, IRecipeSlotsView slots, GuiGraphics gfx, double mouseX, double mouseY) {
+        var recipe = recipeHolder.value();
 		var matrix = gfx.pose();
 
 		matrix.pushPose();
@@ -75,7 +77,8 @@ public class UltimateTableCategory implements IRecipeCategory<ITableRecipe> {
 	}
 
 	@Override
-	public void getTooltip(ITooltipBuilder tooltip, ITableRecipe recipe, IRecipeSlotsView slots, double mouseX, double mouseY) {
+	public void getTooltip(ITooltipBuilder tooltip, RecipeHolder<ITableRecipe> recipeHolder, IRecipeSlotsView slots, double mouseX, double mouseY) {
+        var recipe = recipeHolder.value();
 		var shapeless = recipe instanceof ShapelessTableRecipe;
 		int sX = (shapeless ? 286 : 306) / 2, sY = 329 / 2;
 
@@ -85,7 +88,8 @@ public class UltimateTableCategory implements IRecipeCategory<ITableRecipe> {
 	}
 
 	@Override
-	public void setRecipe(IRecipeLayoutBuilder builder, ITableRecipe recipe, IFocusGroup focuses) {
+	public void setRecipe(IRecipeLayoutBuilder builder, RecipeHolder<ITableRecipe> recipeHolder, IFocusGroup focuses) {
+        var recipe = recipeHolder.value();
 		var level = Minecraft.getInstance().level;
 
 		assert level != null;

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -34,8 +34,3 @@ license="MIT"
         versionRange="[${cucumber_version},)"
         ordering="NONE"
         side="BOTH"
-    [[dependencies.extendedcrafting]]
-        modId="jei"
-        mandatory=false
-        versionRange="[19.16.5.185,)"
-        ordering="NONE"

--- a/src/main/resources/META-INF/neoforge.mods.toml
+++ b/src/main/resources/META-INF/neoforge.mods.toml
@@ -34,3 +34,8 @@ license="MIT"
         versionRange="[${cucumber_version},)"
         ordering="NONE"
         side="BOTH"
+    [[dependencies.extendedcrafting]]
+        modId="jei"
+        mandatory=false
+        versionRange="[19.16.5.185,)"
+        ordering="NONE"


### PR DESCRIPTION
This pull request refactors how recipes are handled and displayed in JEI (Just Enough Items) integration for the mod. The main focus is on switching all recipe categories and related methods to use the new `RecipeHolder<T>` type

**JEI Integration Refactor:**

* All JEI recipe categories (`CombinationCraftingCategory`, `CompressorCraftingCategory`, `EnderCrafterCategory`, `FluxCraftingCategory`, `AdvancedTableCategory`, and `BasicTableCategory`) now use `RecipeHolder<T>` instead of the raw recipe type, updating constructors, method signatures, and internal logic accordingly.

**Recipe Registration Updates:**

* The recipe registration logic in `JeiCompat.java` is updated to use `RecipeHelper.byType(...).stream().toList()` instead of the deprecated `byTypeValues`, aligning with the new `RecipeHolder<T>` approach. Filtering logic is also updated to reference the correct holder structure.
**Dependency Update:**

* The JEI dependency version is bumped from `19.16.1.156` to `19.16.5.185` in `gradle.properties`, to use new function `RecipeType.createRecipeHolderType` 

Actually, I need the recipe id values to create addons for the Extended Crafting mod I'm developing.
